### PR TITLE
Add configurations for link-local networking for OPi images

### DIFF
--- a/OPi5_CIDATA/network-config
+++ b/OPi5_CIDATA/network-config
@@ -14,8 +14,6 @@
 #
 # https://en.wikipedia.org/wiki/YAML
 
-# Some additional examples are commented out below
-
 network:
   version: 2
   renderer: NetworkManager
@@ -26,10 +24,36 @@ network:
         name: "en*"
       dhcp4: true
       optional: true
+      networkmanager:
+        passthrough:
+          connection.autoconnect-priority: 50
+          connection.autoconnect-retries: 2
     zz-all-eth:
       renderer: NetworkManager
       match:
         name: "eth*"
       dhcp4: true
       optional: true
-
+      networkmanager:
+        passthrough:
+          connection.autoconnect-priority: 50
+          connection.autoconnect-retries: 2
+    # Link-local as fallback for direct connection
+    zz-all-en-ll:
+      match:
+        name: en*
+      dhcp4: false
+      link-local: [ ipv4 ]
+      renderer: NetworkManager
+      networkmanager:
+        passthrough:
+          connection.autoconnect-priority: -1
+    zz-all-eth-ll:
+      match:
+        name: eth*
+      dhcp4: false
+      link-local: [ ipv4 ]
+      renderer: NetworkManager
+      networkmanager:
+        passthrough:
+          connection.autoconnect-priority: -1


### PR DESCRIPTION
When directly connected to a device, rather than through a switch, there is no DHCP server available. We can use link-local addresses to make the device automatically connect to client machines over link-local addressing.

On startup, the Orange Pi will attempt to connect via DHCP first, and only enable link-local if it cannot connect to a DHCP server after a few minutes.